### PR TITLE
Fixed label in page header

### DIFF
--- a/inst/rmarkdown/templates/data/skeleton/_template.html
+++ b/inst/rmarkdown/templates/data/skeleton/_template.html
@@ -204,7 +204,7 @@
                 <header class="heading">
                   <div class="ds_page-header">
                     $if(sgtemplates.metadata.label)$
-                      <span class="ds_page-header__label ds_content-label">Report</span>
+                      <span class="ds_page-header__label ds_content-label">$sgtemplates.metadata.label$</span>
                     $endif$
                     <h1 class="ds_page-header__title title toc-ignore">$title$</h1>
                     $if(subtitle)$


### PR DESCRIPTION
Fix issue in HTML template where regardless of what was entered under metadata: label: in the R markdown file, the page would always show "report".